### PR TITLE
Fix name for Generated Style sheets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ enablePlugins(ScalaJSPlugin)
 
 name := "react4s"
 organization := "com.github.ahnfelt"
-version := "0.9.27-SNAPSHOT"
+version := "0.9.28-SNAPSHOT"
 
 // Publish cross versions with: sbt +publish
-crossScalaVersions := Seq("2.11.8", "2.12.5", scalaVersion.value)
+crossScalaVersions := Seq("2.11.8", "2.12.11", scalaVersion.value)
 scalaVersion := "2.13.0"
 scalacOptions += "-feature"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")

--- a/src/main/scala/com/github/ahnfelt/react4s/Component.scala
+++ b/src/main/scala/com/github/ahnfelt/react4s/Component.scala
@@ -247,7 +247,7 @@ private[react4s] case class ContextConsumer(contextType : Any, body : Any => Nod
 abstract class CssClass(val children : CssChild*) extends Tag with CssChild {
     override def toString : String = name
     def toCss : String = CssChild.cssToString(this)
-    val name = getClass.getSimpleName + "-" + getClass.getName.hashCode.toHexString
+    val name = (getClass.getSimpleName + "-" + getClass.getName.hashCode.toHexString).replaceAll("\\$", "")
 }
 
 /** CSS keyframes that will be inserted into the DOM the first time it's used to render a component. When keyframes are used in a CssClass, the appropriate animation-name rule is automatically inserted. Be careful not to create these dynamically, or you'll end up filling up the DOM with keyframes. */
@@ -259,7 +259,7 @@ abstract class CssKeyframes(val keyframes : (String, Seq[Style])*) extends CssCh
             "  " + at + " {\n" + styles.map("    " + _).mkString("\n") + "\n  }\n"
         }).mkString +
         "}\n"
-    val name = getClass.getSimpleName + "-" + getClass.getName.hashCode.toHexString
+    val name = (getClass.getSimpleName + "-" + getClass.getName.hashCode.toHexString).replaceAll("\\$", "")
 }
 
 /** A style, eg. color: rgb(255, 0, 0). Can be used inline to style an Element or in a CssClass. */


### PR DESCRIPTION
Bump Scala sub version for 2.12, bum ScalaJS version,
Fix name for Generated Style sheets, apparently names having an embedded $ are not valid in a browser.